### PR TITLE
Copy artifacts to a temporary directory and delete build directory on completion

### DIFF
--- a/orthanc-big/Dockerfile
+++ b/orthanc-big/Dockerfile
@@ -4,14 +4,14 @@ ARG orthanc_branch='default'
 MAINTAINER Sebastien Jodogne <s.jodogne@gmail.com>
 LABEL Description="Orthanc, free DICOM server" Vendor="The Orthanc project"
 
+RUN echo "deb http://http.us.debian.org/debian stable main contrib non-free" | tee /etc/apt/sources.list.d/debian.list
 RUN apt-get -y clean && apt-get -y update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install wget nano build-essential unzip \
     cmake mercurial uuid-dev libcurl4-openssl-dev liblua5.1-0-dev libgtest-dev libpng-dev \
     libsqlite3-dev libssl-dev libjpeg-dev zlib1g-dev libdcmtk2-dev libboost-all-dev libwrap0-dev \
-    libcharls-dev libjsoncpp-dev libpugixml-dev && apt-get clean && rm -rf /var/lib/apt/lists/*
-RUN echo "deb http://http.us.debian.org/debian stable main contrib non-free" | tee /etc/apt/sources.list.d/debian.list
-RUN apt-get -y update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install locales
+    libcharls-dev libjsoncpp-dev libpugixml-dev locales && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /root/artifacts
 
 ADD ./build-orthanc.sh /root/build-orthanc.sh
 RUN bash /root/build-orthanc.sh "$orthanc_branch"
@@ -34,10 +34,10 @@ RUN mkdir -p /var/lib/orthanc/db && \
     mkdir -p /usr/local/share/orthanc/plugins/
 
 COPY --from=builder /etc/orthanc /etc/orthanc
-COPY --from=builder /root/orthanc/Build/Orthanc /usr/local/sbin/
-COPY --from=builder /root/orthanc/Build/libConnectivityChecks.so /usr/local/share/orthanc/plugins/
-COPY --from=builder /root/orthanc/Build/libModalityWorklists.so /usr/local/share/orthanc/plugins/
-COPY --from=builder /root/orthanc/Build/libServeFolders.so /usr/local/share/orthanc/plugins/
+COPY --from=builder /root/artifacts/Orthanc /usr/local/sbin/
+COPY --from=builder /root/artifacts/libConnectivityChecks.so /usr/local/share/orthanc/plugins/
+COPY --from=builder /root/artifacts/libModalityWorklists.so /usr/local/share/orthanc/plugins/
+COPY --from=builder /root/artifacts/libServeFolders.so /usr/local/share/orthanc/plugins/
 
 VOLUME [ "/var/lib/orthanc/db" ]
 EXPOSE 4242

--- a/orthanc-big/build-orthanc.sh
+++ b/orthanc-big/build-orthanc.sh
@@ -72,9 +72,15 @@ update-locale
 # Install the Orthanc core
 make install
 
+# Copy the artifacts to the artifacts directory, -L to ensure the file and not a link is copied
+cp -L Orthanc /root/artifacts
+cp -L libConnectivityChecks.so /root/artifacts
+cp -L libModalityWorklists.so /root/artifacts
+cp -L libServeFolders.so /root/artifacts
+
 # Remove the build directory to recover space
-# cd /root/
-# rm -rf /root/orthanc
+cd /root/
+rm -rf /root/orthanc
 
 # Auto-generate, then patch the configuration file
 CONFIG=/etc/orthanc/orthanc.json

--- a/orthanc-plugins-big/Dockerfile
+++ b/orthanc-plugins-big/Dockerfile
@@ -20,6 +20,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install wget nano build-essential 
     libcharls-dev libjsoncpp-dev libpugixml-dev libgdcm2-dev postgresql-server-dev-all libtiff-dev libopenslide-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+RUN mkdir -p /root/artifacts/
+
 ADD ./build-orthanc.sh /root/build-orthanc.sh
 RUN bash /root/build-orthanc.sh "$orthanc_branch"
 
@@ -50,21 +52,22 @@ RUN mkdir -p /var/lib/orthanc/db && \
     mkdir -p /usr/local/share/orthanc/plugins/
 
 COPY --from=builder /etc/orthanc /etc/orthanc
-COPY --from=builder /root/orthanc/Build/Orthanc /usr/local/sbin/
-COPY --from=builder /root/orthanc-wsi/Applications/Build/OrthancWSIDicomizer /usr/local/bin/
-COPY --from=builder /root/orthanc-wsi/Applications/Build/OrthancWSIDicomToTiff /usr/local/bin/
-COPY --from=builder /root/orthanc/Build/libConnectivityChecks.so /usr/local/share/orthanc/plugins/
-COPY --from=builder /root/orthanc/Build/libModalityWorklists.so /usr/local/share/orthanc/plugins/
-COPY --from=builder /root/orthanc/Build/libServeFolders.so /usr/local/share/orthanc/plugins/
+COPY --from=builder /root/artifacts/Orthanc /usr/local/sbin/
+COPY --from=builder /root/artifacts/OrthancWSIDicomizer /usr/local/bin/
+COPY --from=builder /root/artifacts/OrthancWSIDicomToTiff /usr/local/bin/
 
-COPY --from=builder /root/orthanc-dicomweb/Build/libOrthancDicomWeb.so /usr/local/share/orthanc/plugins/
-COPY --from=builder /root/orthanc-databases/PostgreBuild/libOrthancPostgreSQLIndex.so /usr/local/share/orthanc/plugins/
-COPY --from=builder /root/orthanc-databases/PostgreBuild/libOrthancPostgreSQLStorage.so /usr/local/share/orthanc/plugins/
-COPY --from=builder /root/orthanc-databases/MariaSQLBuild/libOrthancMySQLIndex.so /usr/local/share/orthanc/plugins/
-COPY --from=builder /root/orthanc-databases/MariaSQLBuild/libOrthancMySQLStorage.so /usr/local/share/orthanc/plugins/
-COPY --from=builder /root/orthanc-webviewer/Build/libOrthancWebViewer.so /usr/local/share/orthanc/plugins/
-COPY --from=builder /root/orthanc-wsi/ViewerPlugin/Build/libOrthancWSI.so /usr/local/share/orthanc/plugins/
-COPY --from=builder /root/orthanc-gdcm/Build/libOrthancGdcm.so /usr/local/share/orthanc/plugins/
+COPY --from=builder /root/artifacts/libConnectivityChecks.so /usr/local/share/orthanc/plugins/
+COPY --from=builder /root/artifacts/libModalityWorklists.so /usr/local/share/orthanc/plugins/
+COPY --from=builder /root/artifacts/libServeFolders.so /usr/local/share/orthanc/plugins/
+
+COPY --from=builder /root/artifacts/libOrthancDicomWeb.so /usr/local/share/orthanc/plugins/
+COPY --from=builder /root/artifacts/libOrthancPostgreSQLIndex.so /usr/local/share/orthanc/plugins/
+COPY --from=builder /root/artifacts/libOrthancPostgreSQLStorage.so /usr/local/share/orthanc/plugins/
+COPY --from=builder /root/artifacts/libOrthancMySQLIndex.so /usr/local/share/orthanc/plugins/
+COPY --from=builder /root/artifacts/libOrthancMySQLStorage.so /usr/local/share/orthanc/plugins/
+COPY --from=builder /root/artifacts/libOrthancWebViewer.so /usr/local/share/orthanc/plugins/
+COPY --from=builder /root/artifacts/libOrthancWSI.so /usr/local/share/orthanc/plugins/
+COPY --from=builder /root/artifacts/libOrthancGdcm.so /usr/local/share/orthanc/plugins/
 
 
 VOLUME [ "/var/lib/orthanc/db" ]

--- a/orthanc-plugins-big/build-databases.sh
+++ b/orthanc-plugins-big/build-databases.sh
@@ -40,8 +40,8 @@ cmake -DALLOW_DOWNLOADS:BOOL=ON \
     ../PostgreSQL
 make -j$COUNT_CORES
 # ./UnitTests # Need postgres server
-cp -L libOrthancPostgreSQLIndex.so /usr/share/orthanc/plugins/
-cp -L libOrthancPostgreSQLStorage.so /usr/share/orthanc/plugins/
+cp -L libOrthancPostgreSQLIndex.so /root/artifacts/
+cp -L libOrthancPostgreSQLStorage.so /root/artifacts/
 
 # Build the MariaSQL plugin
 cd ../
@@ -53,5 +53,9 @@ cmake -DALLOW_DOWNLOADS:BOOL=ON \
     ../MySQL
 make -j$COUNT_CORES
 # ./UnitTests
-cp -L libOrthancMySQLIndex.so /usr/share/orthanc/plugins/
-cp -L libOrthancMySQLStorage.so /usr/share/orthanc/plugins/
+cp -L libOrthancMySQLIndex.so /root/artifacts/
+cp -L libOrthancMySQLStorage.so /root/artifacts/
+
+# Remove the build directory to recover space
+cd /root/
+rm -rf /root/orthanc-databases

--- a/orthanc-plugins-big/build-dicomweb.sh
+++ b/orthanc-plugins-big/build-dicomweb.sh
@@ -43,5 +43,8 @@ cmake -DALLOW_DOWNLOADS:BOOL=ON \
     ..
 make -j$COUNT_CORES
 ./UnitTests
-cp -L libOrthancDicomWeb.so /usr/share/orthanc/plugins/
+cp -L libOrthancDicomWeb.so /root/artifacts/
 
+# Remove the build directory to recover space
+cd /root/
+rm -rf /root/orthanc-dicomweb

--- a/orthanc-plugins-big/build-gdcm.sh
+++ b/orthanc-plugins-big/build-gdcm.sh
@@ -42,5 +42,8 @@ cmake -DALLOW_DOWNLOADS:BOOL=ON \
     -DUSE_SYSTEM_PUGIXML:BOOL=OFF \
     ..
 make -j$COUNT_CORES
-cp -L libOrthancGdcm.so /usr/share/orthanc/plugins/
+cp -L libOrthancGdcm.so /root/artifacts/
 
+# Remove the build directory to recover space
+cd /root/
+rm -rf /root/orthanc-gdcm

--- a/orthanc-plugins-big/build-orthanc.sh
+++ b/orthanc-plugins-big/build-orthanc.sh
@@ -72,6 +72,12 @@ update-locale
 # Install the Orthanc core
 make install
 
+# Copy the artifacts to the artifacts directory, -L to ensure the file and not a link is copied
+cp -L Orthanc /root/artifacts
+cp -L libConnectivityChecks.so /root/artifacts/
+cp -L libModalityWorklists.so /root/artifacts/
+cp -L libServeFolders.so /root/artifacts/
+
 # Remove the build directory to recover space
 # cd /root/
 # rm -rf /root/orthanc

--- a/orthanc-plugins-big/build-webviewer.sh
+++ b/orthanc-plugins-big/build-webviewer.sh
@@ -42,4 +42,8 @@ cmake -DALLOW_DOWNLOADS:BOOL=ON \
     ..
 make -j$COUNT_CORES
 ./UnitTests
-# cp -L libOrthancWebViewer.so /usr/share/orthanc/plugins/
+cp -L libOrthancWebViewer.so /root/artifacts/
+
+# Remove the build directory to recover space
+cd /root/
+rm -rf /root/orthanc-webviewer

--- a/orthanc-plugins-big/build-wsi.sh
+++ b/orthanc-plugins-big/build-wsi.sh
@@ -41,7 +41,7 @@ cmake -DALLOW_DOWNLOADS:BOOL=ON \
     -DUSE_SYSTEM_JSONCPP:BOOL=OFF \
     ..
 make -j$COUNT_CORES
-cp -L libOrthancWSI.so /usr/share/orthanc/plugins/
+cp -L libOrthancWSI.so /root/artifacts/
 
 # Build the DICOM-ization applications
 cd /root/orthanc-wsi/Applications
@@ -54,4 +54,9 @@ cmake -DALLOW_DOWNLOADS:BOOL=ON \
     ..
 make -j$COUNT_CORES
 # make install
+cp -L OrthancWSIDicomizer /root/artifacts/
+cp -L OrthancWSIDicomToTiff /root/artifacts/
 
+# Remove the build directory to recover space
+cd /root/
+rm -rf /root/orthanc-wsi


### PR DESCRIPTION

This should save space on intermediate layers.